### PR TITLE
Small cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,7 @@ cache:
 install:
   - make dependencies
 script:
-  - make coveralls
+  - make test
   - make lint
+after_success:
+  - make coveralls

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ test:
 	go test -race $(PKGS)
 
 .PHONY: coveralls
-coveralls: test
-	goveralls -service=travis-ci
+coveralls:
+	goveralls -service=travis-ci .
 
 .PHONY: bench
 BENCH ?= .

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ endif
 
 .PHONY: lint
 lint:
+ifdef SHOULD_LINT
 	@rm -rf lint.log
 	@echo "Checking formatting..."
 	@gofmt -d -s $(PKG_FILES) 2>&1 | tee lint.log
@@ -45,14 +46,17 @@ lint:
 	@echo "Checking for unresolved FIXMEs..."
 	@git grep -i fixme | grep -v -e vendor -e Makefile | tee -a lint.log
 	@[ ! -s lint.log ]
+else
+	@echo "Skipping linters on" $(GO_VERSION)
+endif
 
 .PHONY: test
 test:
 	go test -race $(PKGS)
 
 .PHONY: coveralls
-coveralls:
-	goveralls -service=travis-ci $(PKGS)
+coveralls: test
+	goveralls -service=travis-ci
 
 .PHONY: bench
 BENCH ?= .

--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ context to your log messages. It strives to avoid serialization overhead and
 allocations wherever possible, so collecting rich debug logs doesn't impact
 normal operations.
 
-As measured by its own benchmarking suite, not only is zap more performant
-than comparable structured logging libraries &mdash; it's also faster than the
-standard library. Like all benchmarks, take these with a grain of salt.
+As measured by its own [benchmarking suite][], not only is zap more
+performant than comparable structured logging libraries &mdash; it's also faster
+than the standard library. Like all benchmarks, take these with a grain of
+salt.<sup id="anchor-versions">[1](#footnote-versions)</sup>
 
 Log a message and 10 fields:
 
@@ -73,9 +74,15 @@ Ready for adventurous users, but breaking API changes are likely.
 <hr>
 Released under the [MIT License](LICENSE.txt).
 
+<sup id="footnote-versions">1</sup> In particular, note that we may be
+benchmarking against slightly older versions of other libraries. Versions are
+pinned in zap's [glide.lock][] file. [↩](#anchor-versions)
+
 [doc-img]: https://godoc.org/github.com/uber-common/zap?status.svg
 [doc]: https://godoc.org/github.com/uber-common/zap
 [ci-img]: https://travis-ci.org/uber-common/zap.svg?branch=master
 [ci]: https://travis-ci.org/uber-common/zap
 [cov-img]: https://coveralls.io/repos/github/uber-common/zap/badge.svg?branch=master
 [cov]: https://coveralls.io/github/uber-common/zap?branch=master
+[benchmarking suite]: https://github.com/uber-common/zap/tree/master/benchmarks
+[glide.lock]: https://github.com/uber-common/zap/blob/master/glide.lock

--- a/doc.go
+++ b/doc.go
@@ -18,5 +18,5 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package zap provides efficient, structured, leveled logging in Go.
+// Package zap provides fast, structured, leveled logging in Go.
 package zap

--- a/example_test.go
+++ b/example_test.go
@@ -45,6 +45,11 @@ func Example() {
 	// log output, but doesn't affect the parent.
 	child := logger.With(zap.String("user", "jane@test.com"), zap.Int("visits", 42))
 	child.Error("Oh no!")
+
+	// Output:
+	// {"msg":"Log without structured data...","level":"warn","ts":0,"fields":{}}
+	// {"msg":"Or use strongly-typed wrappers to add structured context.","level":"warn","ts":0,"fields":{"library":"zap","latency":1}}
+	// {"msg":"Oh no!","level":"error","ts":0,"fields":{"user":"jane@test.com","visits":42}}
 }
 
 func ExampleNest() {

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,26 @@
-hash: c287f70882073416105c80f4bb3e6b592ee8411c1b6afcc33065202fc1b0b6af
-updated: 2016-04-05T16:02:15.890845919-07:00
+hash: 7d8e99769b636ec8b079ce78a6810dfb4e9396c8b1068296924790006f93ed50
+updated: 2016-04-05T23:08:57.795320664-07:00
 imports:
+- name: github.com/axw/gocov
+  version: f5b2b5cf8644b8b432436eaee1c8a73d2f4cf86e
+  subpackages:
+  - gocov
 - name: github.com/go-kit/kit
   version: 2ecaaad4b9ff04d9da92fe4babb270c54d88841f
   subpackages:
   - log
 - name: github.com/go-logfmt/logfmt
   version: 08ab82a63ef462ac643ec79e659f023891f588f5
+- name: github.com/golang/lint
+  version: 8f348af5e29faa4262efdc14302797f23774e477
+  subpackages:
+  - golint
+- name: github.com/mattn/go-colorable
+  version: 9cbef7c35391cca05f15f8181dc0b18bc9736dbb
+- name: github.com/mattn/goveralls
+  version: b8787b61088a1fa0593616c35add0ba8a412fc85
+- name: github.com/pborman/uuid
+  version: c55201b036063326c5b1b89ccfe45a184973d073
 - name: github.com/Sirupsen/logrus
   version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
 - name: github.com/stretchr/testify
@@ -14,6 +28,10 @@ imports:
   subpackages:
   - assert
   - require
+- name: golang.org/x/tools
+  version: fe1488f8abd7e0eea44f1950dad93a6ff6880a60
+  subpackages:
+  - cover
 - name: gopkg.in/inconshreveable/log15.v2
   version: b105bd37f74e5d9dc7b6ad7806715c7a2b83fd3f
 - name: gopkg.in/stack.v1

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,3 +11,15 @@ import:
 - package: github.com/go-logfmt/logfmt
 - package: gopkg.in/stack.v1
 - package: gopkg.in/inconshreveable/log15.v2
+- package: github.com/axw/gocov
+  subpackages:
+  - gocov
+- package: github.com/mattn/goveralls
+- package: golang.org/x/tools
+  subpackages:
+  - cover
+- package: github.com/pborman/uuid
+- package: github.com/golang/lint
+  subpackages:
+  - golint
+- package: github.com/mattn/go-colorable

--- a/logger_test.go
+++ b/logger_test.go
@@ -176,3 +176,21 @@ func TestJSONLoggerInternalErrorHandling(t *testing.T) {
 	// Internal errors go to stderr.
 	assert.Equal(t, "fail\n", errBuf.String(), "Expected internal errors to print to stderr.")
 }
+
+func TestJSONLoggerRuntimeLevelChange(t *testing.T) {
+	// Test that changing a logger's level also changes the level of all
+	// ancestors and descendants.
+	grandparent := NewJSON(Info, ioutil.Discard, Int("generation", 1))
+	parent := grandparent.With(Int("generation", 2))
+	child := parent.With(Int("generation", 3))
+
+	all := []Logger{grandparent, parent, child}
+	for _, logger := range all {
+		assert.Equal(t, Info, logger.Level(), "Expected all loggers to start at Info level.")
+	}
+
+	parent.SetLevel(Debug)
+	for _, logger := range all {
+		assert.Equal(t, Debug, logger.Level(), "Expected all loggers to switch to Debug level.")
+	}
+}


### PR DESCRIPTION
1. Add links to the competitive benchmarking suite and the lock file to the README.
2. Add an output assertion to the package-level example.
3. Make the package-level GoDoc match the GitHub repo description.
4. Add a test for runtime log level changes.
5. Fix the Makefile and Glide manifest for Travis.
6. Only attempt to use the Coveralls API after tests pass, and don't fail the build if the API is flaky.