### PR TITLE
Specify an error sink when creating the logger

### DIFF
--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -51,7 +51,7 @@ var _jane = user{
 }
 
 func BenchmarkZapAddingFields(b *testing.B) {
-	logger := zap.NewJSON(zap.All, ioutil.Discard)
+	logger := zap.NewJSON(zap.All, ioutil.Discard, ioutil.Discard)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -72,7 +72,7 @@ func BenchmarkZapAddingFields(b *testing.B) {
 }
 
 func BenchmarkZapWithAccumulatedContext(b *testing.B) {
-	logger := zap.NewJSON(zap.All, ioutil.Discard,
+	logger := zap.NewJSON(zap.All, ioutil.Discard, ioutil.Discard,
 		zap.Int("int", 1),
 		zap.Int64("int64", 2),
 		zap.Float64("float", 3.0),
@@ -93,7 +93,7 @@ func BenchmarkZapWithAccumulatedContext(b *testing.B) {
 }
 
 func BenchmarkZapWithoutFields(b *testing.B) {
-	logger := zap.NewJSON(zap.All, ioutil.Discard)
+	logger := zap.NewJSON(zap.All, ioutil.Discard, ioutil.Discard)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {

--- a/example_test.go
+++ b/example_test.go
@@ -29,7 +29,7 @@ import (
 
 func Example() {
 	// Log in JSON, using zap's reflection-free JSON encoder.
-	logger := zap.NewJSON(zap.Info, os.Stdout)
+	logger := zap.NewJSON(zap.Info, os.Stdout, os.Stderr)
 	// For repeatable tests, pretend that it's always 1970.
 	logger.StubTime()
 
@@ -53,7 +53,7 @@ func Example() {
 }
 
 func ExampleNest() {
-	logger := zap.NewJSON(zap.Info, os.Stdout)
+	logger := zap.NewJSON(zap.Info, os.Stdout, os.Stderr)
 	// Stub the current time in tests.
 	logger.StubTime()
 

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -49,7 +49,7 @@ var _jane = user{
 }
 
 func withBenchedLogger(b *testing.B, f func(zap.Logger)) {
-	logger := zap.NewJSON(zap.All, ioutil.Discard)
+	logger := zap.NewJSON(zap.All, ioutil.Discard, ioutil.Discard)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -146,7 +146,7 @@ func Benchmark10Fields(b *testing.B) {
 
 func Benchmark100Fields(b *testing.B) {
 	const batchSize = 50
-	logger := zap.NewJSON(zap.All, ioutil.Discard)
+	logger := zap.NewJSON(zap.All, ioutil.Discard, ioutil.Discard)
 
 	// Don't include allocating these helper slices in the benchmark. Since
 	// access to them isn't synchronized, we can't run the benchmark in


### PR DESCRIPTION
We had a `errW` that was not being used, wired up a new parameter to `NewJSON` that is used as the error sink. If it's nil, we use `_defaultErrSink`.

I'm not a fan of the new parameter, maybe we need to go the functional options route (with `NewLogger` not needing any parameters, but using some defaults like "log everything to stdout". Can do that as a follow up if you agree with that approach.