### PR TITLE
Add hooks to logger

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -73,7 +73,7 @@ func ExampleNewJSON() {
 	logger.StubTime()
 
 	// The default logger does not print Debug logs.
-	logger.Debug("this won't be printed")
+	logger.Debug("This won't be printed.")
 	logger.Info("This is an info log.")
 
 	// Output:

--- a/hook.go
+++ b/hook.go
@@ -22,6 +22,7 @@ package zap
 
 import (
 	"errors"
+	"path/filepath"
 	"runtime"
 	"strconv"
 )
@@ -53,7 +54,7 @@ func AddCaller() Option {
 		// Re-use a buffer from the pool.
 		enc := newJSONEncoder()
 		buf := enc.bytes
-		buf = append(buf, filename...)
+		buf = append(buf, filepath.Base(filename)...)
 		buf = append(buf, ':')
 		buf = strconv.AppendInt(buf, int64(line), 10)
 		buf = append(buf, ':', ' ')

--- a/hook.go
+++ b/hook.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import (
+	"errors"
+	"runtime"
+	"strconv"
+)
+
+// Skip Caller, Logger.log, and the leveled Logger method when using
+// runtime.Caller.
+var _callerSkip = 3
+
+// A hook is executed each time the Logger writes a message. It receives the
+// message's priority, the message itself, and the logging context, and it
+// returns a modified message and an error.
+type hook func(Level, string, KeyValue) (string, error)
+
+// apply implements the Option interface.
+func (h hook) apply(jl *jsonLogger) error {
+	jl.hooks = append(jl.hooks, h)
+	return nil
+}
+
+// AddCaller configures the Logger to annotate each message with the filename
+// and line number of zap's caller.
+func AddCaller() Option {
+	return hook(func(_ Level, msg string, _ KeyValue) (string, error) {
+		_, filename, line, ok := runtime.Caller(_callerSkip)
+		if !ok {
+			return msg, errors.New("failed to get caller")
+		}
+
+		// Re-use a buffer from the pool.
+		enc := newJSONEncoder()
+		buf := enc.bytes
+		buf = append(buf, filename...)
+		buf = append(buf, ':')
+		buf = strconv.AppendInt(buf, int64(line), 10)
+		buf = append(buf, ':', ' ')
+		buf = append(buf, msg...)
+
+		newMsg := string(buf)
+		enc.Free()
+		return newMsg, nil
+	})
+}
+
+// AddStacks configures the Logger to record a stack trace for all messages at
+// or above a given level. Keep in mind that this is (relatively speaking) quite
+// expensive.
+func AddStacks(lvl Level) Option {
+	return hook(func(msgLevel Level, msg string, kv KeyValue) (string, error) {
+		if msgLevel >= lvl {
+			Stack().addTo(kv)
+		}
+		return msg, nil
+	})
+}

--- a/hook_test.go
+++ b/hook_test.go
@@ -34,7 +34,7 @@ func TestHookAddCaller(t *testing.T) {
 	logger := NewJSON(All, Output(buf), AddCaller())
 	logger.Info("Callers.")
 
-	re := regexp.MustCompile(`hook_test.go:[\d]+: Callers\.`)
+	re := regexp.MustCompile(`"msg":"hook_test.go:[\d]+: Callers\."`)
 	assert.Regexp(t, re, buf.String(), "Expected to find package name and file name in output.")
 }
 
@@ -55,9 +55,17 @@ func TestHookAddCallerFail(t *testing.T) {
 func TestHookAddStacks(t *testing.T) {
 	buf := &bytes.Buffer{}
 	logger := NewJSON(All, Output(buf), AddStacks(Info))
-	logger.Info("Stacks.")
 
+	logger.Info("Stacks.")
 	output := buf.String()
 	require.Contains(t, output, "zap.TestHookAddStacks", "Expected to find test function in stacktrace.")
 	assert.Contains(t, output, `"stacktrace":`, "Stacktrace added under an unexpected key.")
+
+	buf.Reset()
+	logger.Warn("Stacks.")
+	assert.Contains(t, buf.String(), `"stacktrace":`, "Expected to include stacktrace at Warn level.")
+
+	buf.Reset()
+	logger.Debug("No stacks.")
+	assert.NotContains(t, buf.String(), "Unexpected stacktrace at Debug level.")
 }

--- a/hook_test.go
+++ b/hook_test.go
@@ -34,7 +34,7 @@ func TestHookAddCaller(t *testing.T) {
 	logger := NewJSON(All, Output(buf), AddCaller())
 	logger.Info("Callers.")
 
-	re := regexp.MustCompile(`github\.com\\/uber-common\\/zap\\/hook_test.go:[\d]+: Callers\.`)
+	re := regexp.MustCompile(`hook_test.go:[\d]+: Callers\.`)
 	assert.Regexp(t, re, buf.String(), "Expected to find package name and file name in output.")
 }
 

--- a/hook_test.go
+++ b/hook_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import (
+	"bytes"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHookAddCaller(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewJSON(All, Output(buf), AddCaller())
+	logger.Info("Callers.")
+
+	re := regexp.MustCompile(`github\.com\\/uber-common\\/zap\\/hook_test.go:[\d]+: Callers\.`)
+	assert.Regexp(t, re, buf.String(), "Expected to find package name and file name in output.")
+}
+
+func TestHookAddCallerFail(t *testing.T) {
+	buf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+
+	originalSkip := _callerSkip
+	_callerSkip = 1e3
+	defer func() { _callerSkip = originalSkip }()
+
+	logger := NewJSON(All, Output(buf), ErrorOutput(errBuf), AddCaller())
+	logger.Info("Failure.")
+	assert.Equal(t, "failed to get caller\n", errBuf.String(), "Didn't find expected failure message.")
+	assert.Contains(t, buf.String(), `"msg":"Failure."`, "Expected original message to survive failures in runtime.Caller.")
+}
+
+func TestHookAddStacks(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewJSON(All, Output(buf), AddStacks(Info))
+	logger.Info("Stacks.")
+
+	output := buf.String()
+	require.Contains(t, output, "zap.TestHookAddStacks", "Expected to find test function in stacktrace.")
+	assert.Contains(t, output, `"stacktrace":`, "Stacktrace added under an unexpected key.")
+}

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -133,6 +133,19 @@ func BenchmarkObjectField(b *testing.B) {
 	})
 }
 
+func BenchmarkAddCallerHook(b *testing.B) {
+	logger := zap.NewJSON(
+		zap.Output(ioutil.Discard),
+		zap.AddCaller(),
+	)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Caller.")
+		}
+	})
+}
+
 func Benchmark10Fields(b *testing.B) {
 	withBenchedLogger(b, func(log zap.Logger) {
 		log.Info("Ten fields, passed at the log site.",


### PR DESCRIPTION
Extend the logger to support a variable number of pre-log hooks. The
hooks can alter the in-flight message and/or add to the logging context.

For this first revision, I've included hooks to (a) annotate each log
message with the logging call site, and (b) include stack traces for all
log messages above a given level.