### PR TITLE
Add Stringer field which will call String() method

### DIFF
--- a/field.go
+++ b/field.go
@@ -81,6 +81,12 @@ func String(key string, val string) Field {
 	return Field{key: key, fieldType: stringType, str: val}
 }
 
+// Stringer constructs a Field with the given key and value. The value
+// is the result of the String method.
+func Stringer(key string, val fmt.Stringer) Field {
+	return Field{key: key, fieldType: stringType, str: val.String()}
+}
+
 // Time constructs a Field with the given key and value. It represents a
 // time.Time as nanoseconds since epoch.
 func Time(key string, val time.Time) Field {

--- a/field_test.go
+++ b/field_test.go
@@ -22,6 +22,7 @@ package zap
 
 import (
 	"errors"
+	"net"
 	"strings"
 	"sync"
 	"testing"
@@ -94,6 +95,12 @@ func TestInt64Field(t *testing.T) {
 func TestStringField(t *testing.T) {
 	assertFieldJSON(t, `"foo":"bar"`, String("foo", "bar"))
 	assertCanBeReused(t, String("foo", "bar"))
+}
+
+func TestStringerField(t *testing.T) {
+	ip := net.ParseIP("1.2.3.4")
+	assertFieldJSON(t, `"foo":"1.2.3.4"`, Stringer("foo", ip))
+	assertCanBeReused(t, Stringer("foo", ip))
 }
 
 func TestTimeField(t *testing.T) {

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -94,6 +94,12 @@ func BenchmarkStringField(b *testing.B) {
 	})
 }
 
+func BenchmarkStringerField(b *testing.B) {
+	withBenchedLogger(b, func(log zap.Logger) {
+		log.Info("Level.", zap.Stringer("foo", zap.Info))
+	})
+}
+
 func BenchmarkTimeField(b *testing.B) {
 	t := time.Unix(0, 0)
 	withBenchedLogger(b, func(log zap.Logger) {


### PR DESCRIPTION
This avoids some line noise in log call sites when passing things like `net.IP`, since code like:
```go
zap.Info("Started.", zap.String("ip", ipAddr.String()))
```
becomes:
```go
zap.Info("Started.", zap.Stringer("ip", ipAddr))
```