### PR TITLE
Miscellaneous ergonomic improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # :zap: zap [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
 
-Fast, structured, leveled logging in Go.
+Blazing fast, structured, leveled logging in Go.
 
 ## Structure
 
@@ -22,12 +22,16 @@ dashboarding, and accurate message bucketing. In short, it helps you get the
 most out of tools like ELK, Splunk, and Sentry. All log messages are
 JSON-serialized, though PRs to support other formats are welcome.
 
+For compatibility with the standard library and [bark][], zap provides the
+`zwrap.Standardize` and `zbark.Barkify` wrappers. Both are slower than the core
+zap logger, but faster than the libraries they replace.
+
 ## Performance
 
 For applications that log in the hot path, reflection-based serialization and
 string formatting are prohibitively expensive &mdash; they're CPU-intensive and
 make many small allocations. Put differently, using `encoding/json` and
-`fmt.Println` to log tons of `interface{}`s makes your application slow.
+`fmt.Fprintf` to log tons of `interface{}`s makes your application slow.
 
 Zap takes a different approach. It includes a reflection-free, zero-allocation
 JSON encoder, and it offers a variety of type-safe ways to add structured
@@ -44,29 +48,29 @@ Log a message and 10 fields:
 
 | Library | Time | Bytes Allocated | Objects Allocated |
 | :--- | :---: | :---: | :---: |
-| :zap: zap | 1171 ns/op | 705 B/op | 2 allocs/op |
-| logrus | 8410 ns/op | 3560 B/op | 67 allocs/op |
-| go-kit | 7380 ns/op | 3204 B/op | 70 allocs/op |
-| log15 | 20610 ns/op | 4207 B/op | 90 allocs/op |
+| :zap: zap | 1241 ns/op | 705 B/op | 2 allocs/op |
+| logrus | 9713 ns/op | 5275 B/op | 78 allocs/op |
+| go-kit | 11632 ns/op | 3204 B/op | 70 allocs/op |
+| log15 | 23077 ns/op | 4783 B/op | 91 allocs/op |
 
 Log a message using a logger that already has 10 fields of context:
 
 | Library | Time | Bytes Allocated | Objects Allocated |
 | :--- | :---: | :---: | :---: |
-| :zap: zap | 231 ns/op | 0 B/op | 0 allocs/op |
-| logrus | 8035 ns/op | 3438 B/op | 61 allocs/op |
-| go-kit | 6790 ns/op | 2486 B/op | 48 allocs/op |
-| log15 | 20709 ns/op | 3543 B/op | 69 allocs/op |
+| :zap: zap | 238 ns/op | 0 B/op | 0 allocs/op |
+| logrus | 7946 ns/op | 3438 B/op | 61 allocs/op |
+| go-kit | 6445 ns/op | 2486 B/op | 48 allocs/op |
+| log15 | 21728 ns/op | 4120 B/op | 70 allocs/op |
 
 Log a static string, without any context or `printf`-style formatting:
 
 | Library | Time | Bytes Allocated | Objects Allocated |
 | :--- | :---: | :---: | :---: |
-| :zap: zap | 223 ns/op | 0 B/op | 0 allocs/op |
-| standard library | 562 ns/op | 32 B/op | 2 allocs/op |
-| logrus | 2765 ns/op | 1336 B/op | 26 allocs/op |
-| go-kit | 1092 ns/op | 624 B/op | 13 allocs/op |
-| log15 | 5513 ns/op | 1351 B/op | 23 allocs/op |
+| :zap: zap | 219 ns/op | 0 B/op | 0 allocs/op |
+| standard library | 607 ns/op | 32 B/op | 2 allocs/op |
+| logrus | 3324 ns/op | 1336 B/op | 26 allocs/op |
+| go-kit | 1008 ns/op | 624 B/op | 13 allocs/op |
+| log15 | 5769 ns/op | 1351 B/op | 23 allocs/op |
 
 ## Development Status: Beta
 Ready for adventurous users, but breaking API changes are likely.
@@ -86,3 +90,4 @@ pinned in zap's [glide.lock][] file. [↩](#anchor-versions)
 [cov]: https://coveralls.io/github/uber-common/zap?branch=master
 [benchmarking suite]: https://github.com/uber-common/zap/tree/master/benchmarks
 [glide.lock]: https://github.com/uber-common/zap/blob/master/glide.lock
+[bark]: https://github.com/uber-common/bark

--- a/field.go
+++ b/field.go
@@ -142,9 +142,7 @@ func (f Field) addTo(kv KeyValue) error {
 	case stringType:
 		kv.AddString(f.key, f.str)
 	case marshalerType:
-		return kv.Nest(f.key, func(enc KeyValue) error {
-			return f.obj.MarshalLog(kv)
-		})
+		return kv.AddObject(f.key, f.obj)
 	default:
 		panic(fmt.Sprintf("unknown field type found: %v", f))
 	}

--- a/field.go
+++ b/field.go
@@ -28,11 +28,6 @@ import (
 
 type fieldType int
 
-// A FieldCloser closes a nested field.
-type FieldCloser interface {
-	CloseField()
-}
-
 const (
 	unknownType fieldType = iota
 	boolType
@@ -147,10 +142,9 @@ func (f Field) addTo(kv KeyValue) error {
 	case stringType:
 		kv.AddString(f.key, f.str)
 	case marshalerType:
-		closer := kv.Nest(f.key)
-		err := f.obj.MarshalLog(kv)
-		closer.CloseField()
-		return err
+		return kv.Nest(f.key, func(enc KeyValue) error {
+			return f.obj.MarshalLog(kv)
+		})
 	default:
 		panic(fmt.Sprintf("unknown field type found: %v", f))
 	}

--- a/json_encoder.go
+++ b/json_encoder.go
@@ -116,19 +116,13 @@ func (enc *jsonEncoder) UnsafeAddBytes(key string, val []byte) {
 	enc.bytes = append(enc.bytes, val...)
 }
 
-// Nest starts a nested object and returns a function that closes the nested
-// object. Until the returned function is called, calls to AddString and friends
-// operate on the nested namespace.
-//
-// Failing to use the returned FieldCloser will result in invalid JSON output.
-func (enc *jsonEncoder) Nest(key string) FieldCloser {
+// Nest allows the caller to populate a nested object under the provided key.
+func (enc *jsonEncoder) Nest(key string, f func(KeyValue) error) error {
 	enc.addKey(key)
 	enc.bytes = append(enc.bytes, '{')
-	return enc
-}
-
-func (enc *jsonEncoder) CloseField() {
+	err := f(enc)
 	enc.bytes = append(enc.bytes, '}')
+	return err
 }
 
 // Clone copies the current encoder, including any data already encoded.

--- a/json_encoder.go
+++ b/json_encoder.go
@@ -125,6 +125,13 @@ func (enc *jsonEncoder) Nest(key string, f func(KeyValue) error) error {
 	return err
 }
 
+// AddObject adds a Marshaler to the encoder's fields.
+func (enc *jsonEncoder) AddObject(key string, obj Marshaler) error {
+	return enc.Nest(key, func(kv KeyValue) error {
+		return obj.MarshalLog(kv)
+	})
+}
+
 // Clone copies the current encoder, including any data already encoded.
 func (enc *jsonEncoder) Clone() encoder {
 	clone := newJSONEncoder()

--- a/json_encoder_test.go
+++ b/json_encoder_test.go
@@ -149,6 +149,21 @@ func TestJSONNest(t *testing.T) {
 	})
 }
 
+type loggable struct{}
+
+func (l loggable) MarshalLog(kv KeyValue) error {
+	kv.AddString("loggable", "yes")
+	return nil
+}
+
+func TestJSONAddObject(t *testing.T) {
+	withJSONEncoder(func(enc *jsonEncoder) {
+		err := enc.AddObject("nested", loggable{})
+		require.NoError(t, err, "Unexpected error using AddObject.")
+		assertJSON(t, `"foo":"bar","nested":{"loggable":"yes"}`, enc)
+	})
+}
+
 func TestJSONClone(t *testing.T) {
 	// The parent encoder is created with plenty of excess capacity.
 	parent := &jsonEncoder{bytes: make([]byte, 0, 128)}

--- a/json_encoder_test.go
+++ b/json_encoder_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/uber-common/zap/spy"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func assertJSON(t *testing.T, expected string, enc *jsonEncoder) {
@@ -137,9 +138,11 @@ func TestJSONWriteMessage(t *testing.T) {
 
 func TestJSONNest(t *testing.T) {
 	withJSONEncoder(func(enc *jsonEncoder) {
-		closer := enc.Nest("nested")
-		enc.AddString("sub-foo", "sub-bar")
-		closer.CloseField()
+		err := enc.Nest("nested", func(kv KeyValue) error {
+			kv.AddString("sub-foo", "sub-bar")
+			return nil
+		})
+		require.NoError(t, err, "Unexpected error using Nest.")
 		enc.AddString("baz", "bing")
 
 		assertJSON(t, `"foo":"bar","nested":{"sub-foo":"sub-bar"},"baz":"bing"`, enc)

--- a/keyvalue.go
+++ b/keyvalue.go
@@ -31,5 +31,5 @@ type KeyValue interface {
 	AddInt(string, int)
 	AddInt64(string, int64)
 	AddString(string, string)
-	Nest(string) FieldCloser
+	Nest(string, func(KeyValue) error) error
 }

--- a/keyvalue.go
+++ b/keyvalue.go
@@ -30,6 +30,7 @@ type KeyValue interface {
 	AddFloat64(string, float64)
 	AddInt(string, int)
 	AddInt64(string, int64)
+	AddObject(string, Marshaler) error
 	AddString(string, string)
 	Nest(string, func(KeyValue) error) error
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -175,6 +175,13 @@ func TestJSONLoggerPanic(t *testing.T) {
 	})
 }
 
+func TestJSONLoggerDFatal(t *testing.T) {
+	withJSONLogger(t, []Option{Development()}, func(jl *jsonLogger, output func() []string) {
+		jl.DFatal("foo")
+		assertMessage(t, "error", "foo", output()[0])
+	})
+}
+
 func TestJSONLoggerNoOpsDisabledLevels(t *testing.T) {
 	withJSONLogger(t, nil, func(jl *jsonLogger, output func() []string) {
 		jl.SetLevel(Warn)

--- a/logger_test.go
+++ b/logger_test.go
@@ -176,7 +176,7 @@ func TestJSONLoggerPanic(t *testing.T) {
 }
 
 func TestJSONLoggerDFatal(t *testing.T) {
-	withJSONLogger(t, []Option{Development()}, func(jl *jsonLogger, output func() []string) {
+	withJSONLogger(t, nil, func(jl *jsonLogger, output func() []string) {
 		jl.DFatal("foo")
 		assertMessage(t, "error", "foo", output()[0])
 	})

--- a/marshaler_example_test.go
+++ b/marshaler_example_test.go
@@ -51,8 +51,9 @@ func (u User) MarshalLog(kv zap.KeyValue) error {
 	kv.AddInt("age", u.Age)
 
 	// Put the authentication information in a nested object.
-	defer kv.Nest("auth").CloseField()
-	return u.Auth.MarshalLog(kv)
+	return kv.Nest("auth", func(kv zap.KeyValue) error {
+		return u.Auth.MarshalLog(kv)
+	})
 }
 
 func ExampleMarshaler() {

--- a/marshaler_example_test.go
+++ b/marshaler_example_test.go
@@ -49,11 +49,7 @@ type User struct {
 func (u User) MarshalLog(kv zap.KeyValue) error {
 	kv.AddString("name", u.Name)
 	kv.AddInt("age", u.Age)
-
-	// Put the authentication information in a nested object.
-	return kv.Nest("auth", func(kv zap.KeyValue) error {
-		return u.Auth.MarshalLog(kv)
-	})
+	return kv.AddObject("auth", u.Auth)
 }
 
 func ExampleMarshaler() {

--- a/options.go
+++ b/options.go
@@ -60,3 +60,12 @@ func ErrorOutput(w WriteSyncer) Option {
 		return nil
 	})
 }
+
+// Development puts the logger in development mode, which alters the behavior
+// of the DFatal method.
+func Development() Option {
+	return optionFunc(func(jl *jsonLogger) error {
+		jl.development = true
+		return nil
+	})
+}


### PR DESCRIPTION
This PR introduces a few small ergonomic improvements to zap's APIs (might as well get them in while we're in beta!):

* `Nest` now takes a function to populate the nested namespace, instead of returning a `FieldCloser` and leaving state management up to the user.
* The `KeyValue` interface now has an `AddObject` method which adds a `Marshaler` to the logging context.
* Loggers now have a `DFatal` method and a `Development` option.
* I also updated the benchmarks in the README. In a [previous PR](https://github.com/uber-common/zap/commit/078a0b69f4dce79002c4387d2f9cc99f2d1c3f63), I fixed one of the logrus benchmarks - it's actually even slower than the first round of benchmarks suggested.