### PR TITLE
Add a sampling wrapper

### DIFF
--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -132,7 +132,7 @@ func BenchmarkZapSampleWithoutFields(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			logger.Info("Sample the logs.")
+			logger.Info("Sample the logs, but use a somewhat realistic message length.")
 		}
 	})
 }

--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -126,7 +126,7 @@ func BenchmarkZapWithoutFields(b *testing.B) {
 	})
 }
 
-func BenchmarkSampledZap(b *testing.B) {
+func BenchmarkZapSampleWithoutFields(b *testing.B) {
 	logger := zwrap.Sample(zap.NewJSON(zap.All, zap.Output(zap.Discard)), 10, 100)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {

--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -22,6 +22,7 @@ package benchmarks
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -127,12 +128,18 @@ func BenchmarkZapWithoutFields(b *testing.B) {
 }
 
 func BenchmarkZapSampleWithoutFields(b *testing.B) {
+	messages := make([]string, 1000)
+	for i := range messages {
+		messages[i] = fmt.Sprintf("Sample the logs, but use a somewhat realistic message length. (#%v)", i)
+	}
 	base := zap.NewJSON(zap.All, zap.Output(zap.Discard))
 	logger := zwrap.Sample(base, time.Second, 10, 100)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
+		i := 0
 		for pb.Next() {
-			logger.Info("Sample the logs, but use a somewhat realistic message length.")
+			i++
+			logger.Info(messages[i%1000])
 		}
 	})
 }

--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -127,7 +127,8 @@ func BenchmarkZapWithoutFields(b *testing.B) {
 }
 
 func BenchmarkZapSampleWithoutFields(b *testing.B) {
-	logger := zwrap.Sample(zap.NewJSON(zap.All, zap.Output(zap.Discard)), 10, 100)
+	base := zap.NewJSON(zap.All, zap.Output(zap.Discard))
+	logger := zwrap.Sample(base, time.Second, 10, 100)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {

--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/uber-common/zap"
+	"github.com/uber-common/zap/zwrap"
 )
 
 var errExample = errors.New("fail")
@@ -121,6 +122,16 @@ func BenchmarkZapWithoutFields(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			logger.Info("Go fast.")
+		}
+	})
+}
+
+func BenchmarkSampledZap(b *testing.B) {
+	logger := zwrap.Sample(zap.NewJSON(zap.All, zap.Output(zap.Discard)), 10, 100)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Sample the logs.")
 		}
 	})
 }

--- a/json_encoder_test.go
+++ b/json_encoder_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/uber-common/zap/spy"
+	"github.com/uber-common/zap/spywrite"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -201,8 +201,8 @@ func TestJSONWriteMessageFailure(t *testing.T) {
 			sink io.Writer
 			msg  string
 		}{
-			{spy.FailWriter{}, "Expected an error when writing to sink fails."},
-			{spy.ShortWriter{}, "Expected an error on partial writes to sink."},
+			{spywrite.FailWriter{}, "Expected an error when writing to sink fails."},
+			{spywrite.ShortWriter{}, "Expected an error on partial writes to sink."},
 		}
 		for _, tt := range tests {
 			err := enc.WriteMessage(tt.sink, "info", "hello", time.Unix(0, 0))

--- a/logger.go
+++ b/logger.go
@@ -43,6 +43,9 @@ type Logger interface {
 	// StubTime stops the logger from including the current time in each
 	// message. Instead, it always reports the time as Unix epoch 0. (This is
 	// useful in tests and examples.)
+	//
+	// TODO: remove this kludge in favor of a more comprehensive message-formatting
+	// option.
 	StubTime()
 
 	// Log a message at the given level. Messages include any context that's

--- a/logger_test.go
+++ b/logger_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber-common/zap/spy"
+	"github.com/uber-common/zap/spywrite"
 )
 
 func opts(opts ...Option) []Option {
@@ -200,8 +200,8 @@ func TestJSONLoggerInternalErrorHandling(t *testing.T) {
 
 func TestJSONLoggerWriteMessageFailure(t *testing.T) {
 	errBuf := &bytes.Buffer{}
-	errSink := &spy.WriteSyncer{Writer: errBuf}
-	logger := NewJSON(All, Output(AddSync(spy.FailWriter{})), ErrorOutput(errSink))
+	errSink := &spywrite.WriteSyncer{Writer: errBuf}
+	logger := NewJSON(All, Output(AddSync(spywrite.FailWriter{})), ErrorOutput(errSink))
 
 	logger.Info("foo")
 	// Should log the error.
@@ -228,7 +228,7 @@ func TestJSONLoggerRuntimeLevelChange(t *testing.T) {
 }
 
 func TestJSONLoggerSyncsOutput(t *testing.T) {
-	sink := &spy.WriteSyncer{Writer: ioutil.Discard}
+	sink := &spywrite.WriteSyncer{Writer: ioutil.Discard}
 	logger := NewJSON(All, Output(sink))
 
 	logger.Error("foo")

--- a/spy/logger.go
+++ b/spy/logger.go
@@ -117,9 +117,10 @@ func (l *Logger) SetLevel(new zap.Level) {
 // With creates a new Logger with additional fields added to the logging context.
 func (l *Logger) With(fields ...zap.Field) zap.Logger {
 	return &Logger{
-		level:   l.level,
-		sink:    l.sink,
-		context: append(l.context, fields...),
+		level:       l.level,
+		sink:        l.sink,
+		context:     append(l.context, fields...),
+		development: l.development,
 	}
 }
 

--- a/spy/logger.go
+++ b/spy/logger.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package spy
+
+import (
+	"sync"
+
+	"github.com/uber-common/zap"
+)
+
+// A Log is an encoding-agnostic representation of a log message.
+type Log struct {
+	Level  zap.Level
+	Msg    string
+	Fields []zap.Field
+}
+
+// A Sink stores Log structs.
+type Sink struct {
+	sync.Mutex
+
+	logs []Log
+}
+
+// WriteLog writes a log message to the LogSink.
+func (s *Sink) WriteLog(lvl zap.Level, msg string, fields []zap.Field) {
+	s.Lock()
+	log := Log{
+		Msg:    msg,
+		Level:  lvl,
+		Fields: fields,
+	}
+	s.logs = append(s.logs, log)
+	s.Unlock()
+}
+
+// Logs returns a copy of the sink's accumulated logs.
+func (s *Sink) Logs() []Log {
+	logs := make([]Log, len(s.logs))
+	s.Lock()
+	for i, log := range s.logs {
+		logs[i] = log
+	}
+	s.Unlock()
+	return logs
+}
+
+// Logger satisfies zap.Logger, but makes testing convenient.
+type Logger struct {
+	sync.Mutex
+
+	level       zap.Level
+	sink        *Sink
+	context     []zap.Field
+	development bool
+}
+
+// New returns a new spy logger at the default level.
+func New(sink *Sink) *Logger {
+	return &Logger{
+		// Use the same defaults as the core logger.
+		level: zap.NewJSON().Level(),
+		sink:  sink,
+	}
+}
+
+// StubTime is a no-op, since the spy logger omits time entirely.
+func (l *Logger) StubTime() {}
+
+// SetDevelopment sets the development flag.
+func (l *Logger) SetDevelopment(dev bool) {
+	l.Lock()
+	l.development = dev
+	l.Unlock()
+}
+
+// Enabled checks whether logging at the specified level is enabled.
+func (l *Logger) Enabled(lvl zap.Level) bool {
+	return lvl >= l.Level()
+}
+
+// Level returns the currently-enabled logging level.
+func (l *Logger) Level() zap.Level {
+	l.Lock()
+	defer l.Unlock()
+
+	return l.level
+}
+
+// SetLevel alters the enabled log level.
+func (l *Logger) SetLevel(new zap.Level) {
+	l.Lock()
+	defer l.Unlock()
+
+	l.level = new
+}
+
+// With creates a new Logger with additional fields added to the logging context.
+func (l *Logger) With(fields ...zap.Field) zap.Logger {
+	return &Logger{
+		level:   l.level,
+		sink:    l.sink,
+		context: append(l.context, fields...),
+	}
+}
+
+// Debug logs at the Debug level.
+func (l *Logger) Debug(msg string, fields ...zap.Field) {
+	l.sink.WriteLog(zap.Debug, msg, l.allFields(fields))
+}
+
+// Info logs at the Info level.
+func (l *Logger) Info(msg string, fields ...zap.Field) {
+	l.sink.WriteLog(zap.Info, msg, l.allFields(fields))
+
+}
+
+// Warn logs at the Warn level.
+func (l *Logger) Warn(msg string, fields ...zap.Field) {
+	l.sink.WriteLog(zap.Warn, msg, l.allFields(fields))
+
+}
+
+// Error logs at the Error level.
+func (l *Logger) Error(msg string, fields ...zap.Field) {
+	l.sink.WriteLog(zap.Error, msg, l.allFields(fields))
+
+}
+
+// Panic logs at the Panic level. Note that the spy Logger doesn't actually
+// panic.
+func (l *Logger) Panic(msg string, fields ...zap.Field) {
+	l.sink.WriteLog(zap.Panic, msg, l.allFields(fields))
+
+}
+
+// Fatal logs at the Fatal level. Note that the spy logger doesn't actuall call
+// os.Exit.
+func (l *Logger) Fatal(msg string, fields ...zap.Field) {
+	l.sink.WriteLog(zap.Fatal, msg, l.allFields(fields))
+
+}
+
+// DFatal logs at the Fatal level if the development flag is set, and the Fatal
+// level otherwise.
+func (l *Logger) DFatal(msg string, fields ...zap.Field) {
+	if l.development {
+		l.sink.WriteLog(zap.Fatal, msg, l.allFields(fields))
+	} else {
+		l.sink.WriteLog(zap.Error, msg, l.allFields(fields))
+	}
+}
+
+func (l *Logger) allFields(added []zap.Field) []zap.Field {
+	all := make([]zap.Field, 0, len(added)+len(l.context))
+	all = append(all, l.context...)
+	all = append(all, added...)
+	return all
+}

--- a/spy/logger.go
+++ b/spy/logger.go
@@ -73,13 +73,14 @@ type Logger struct {
 	development bool
 }
 
-// New returns a new spy logger at the default level.
-func New(sink *Sink) *Logger {
+// New returns a new spy logger at the default level and its sink.
+func New() (*Logger, *Sink) {
+	s := &Sink{}
 	return &Logger{
 		// Use the same defaults as the core logger.
 		level: zap.NewJSON().Level(),
-		sink:  sink,
-	}
+		sink:  s,
+	}, s
 }
 
 // StubTime is a no-op, since the spy logger omits time entirely.

--- a/spywrite/doc.go
+++ b/spywrite/doc.go
@@ -18,6 +18,5 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package spy provides an implementation of zap.Logger that helps test
-// logging wrappers.
-package spy
+// Package spywrite provides various I/O implementations with known errors.
+package spywrite

--- a/spywrite/writer.go
+++ b/spywrite/writer.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package spy
+package spywrite
 
 import (
 	"errors"

--- a/writer_test.go
+++ b/writer_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber-common/zap/spy"
+	"github.com/uber-common/zap/spywrite"
 )
 
 type testBuffer struct {
@@ -50,7 +50,7 @@ func requireWriteWorks(t testing.TB, ws WriteSyncer) {
 
 func TestAddSyncWriteSyncer(t *testing.T) {
 	buf := &bytes.Buffer{}
-	concrete := &spy.WriteSyncer{Writer: buf}
+	concrete := &spywrite.WriteSyncer{Writer: buf}
 	ws := AddSync(concrete)
 	requireWriteWorks(t, ws)
 
@@ -63,7 +63,7 @@ func TestAddSyncWriteSyncer(t *testing.T) {
 
 func TestAddSyncWriteFlusher(t *testing.T) {
 	buf := &bytes.Buffer{}
-	concrete := &spy.WriteFlusher{Writer: buf}
+	concrete := &spywrite.WriteFlusher{Writer: buf}
 	ws := AddSync(concrete)
 	requireWriteWorks(t, ws)
 
@@ -76,7 +76,7 @@ func TestAddSyncWriteFlusher(t *testing.T) {
 
 func TestAddSyncWriteFlushSyncer(t *testing.T) {
 	buf := &bytes.Buffer{}
-	concrete := &spy.WriteFlushSyncer{Writer: buf}
+	concrete := &spywrite.WriteFlushSyncer{Writer: buf}
 	ws := AddSync(concrete)
 	requireWriteWorks(t, ws)
 

--- a/zwrap/doc.go
+++ b/zwrap/doc.go
@@ -18,6 +18,5 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package zwrap provides a wrapper to make zap.Loggers compatible with the
-// standard library's log.Logger.
+// Package zwrap provides a variety of wrappers for the core zap logger.
 package zwrap

--- a/zwrap/example_test.go
+++ b/zwrap/example_test.go
@@ -53,14 +53,14 @@ func Example_sample() {
 	// Stub the current time in tests.
 	sampledLogger.StubTime()
 
-	sampledLogger.Error("Unusual failure.")
-
 	for i := 1; i < 110; i++ {
 		sampledLogger.With(zap.Int("n", i)).Error("Common failure.")
 	}
 
+	sampledLogger.Error("Unusual failure.")
+
 	// Output:
-	// {"msg":"Unusual failure.","level":"error","ts":0,"fields":{}}
 	// {"msg":"Common failure.","level":"error","ts":0,"fields":{"n":1}}
 	// {"msg":"Common failure.","level":"error","ts":0,"fields":{"n":101}}
+	// {"msg":"Unusual failure.","level":"error","ts":0,"fields":{}}
 }

--- a/zwrap/example_test.go
+++ b/zwrap/example_test.go
@@ -21,11 +21,13 @@
 package zwrap_test
 
 import (
+	"strconv"
+
 	"github.com/uber-common/zap"
 	"github.com/uber-common/zap/zwrap"
 )
 
-func Example() {
+func Example_standardize() {
 	zapLogger := zap.NewJSON()
 	// Stub the current time in tests.
 	zapLogger.StubTime()
@@ -44,4 +46,19 @@ func Example() {
 
 	// Output:
 	// {"msg":"Encountered 0 errors.","level":"warn","ts":0,"fields":{}}
+}
+
+func Example_sample() {
+	// Log the first message, and every 100th message thereafter.
+	sampledLogger := zwrap.Sample(zap.NewJSON(), 1, 100)
+	// Stub the current time in tests.
+	sampledLogger.StubTime()
+
+	for i := 1; i < 110; i++ {
+		sampledLogger.Error(strconv.Itoa(i))
+	}
+
+	// Output:
+	// {"msg":"1","level":"error","ts":0,"fields":{}}
+	// {"msg":"101","level":"error","ts":0,"fields":{}}
 }

--- a/zwrap/example_test.go
+++ b/zwrap/example_test.go
@@ -21,7 +21,6 @@
 package zwrap_test
 
 import (
-	"strconv"
 	"time"
 
 	"github.com/uber-common/zap"
@@ -50,16 +49,18 @@ func Example_standardize() {
 }
 
 func Example_sample() {
-	// Every second, log the first message and every hundredth message thereafter.
 	sampledLogger := zwrap.Sample(zap.NewJSON(), time.Second, 1, 100)
 	// Stub the current time in tests.
 	sampledLogger.StubTime()
 
+	sampledLogger.Error("Unusual failure.")
+
 	for i := 1; i < 110; i++ {
-		sampledLogger.Error(strconv.Itoa(i))
+		sampledLogger.With(zap.Int("n", i)).Error("Common failure.")
 	}
 
 	// Output:
-	// {"msg":"1","level":"error","ts":0,"fields":{}}
-	// {"msg":"101","level":"error","ts":0,"fields":{}}
+	// {"msg":"Unusual failure.","level":"error","ts":0,"fields":{}}
+	// {"msg":"Common failure.","level":"error","ts":0,"fields":{"n":1}}
+	// {"msg":"Common failure.","level":"error","ts":0,"fields":{"n":101}}
 }

--- a/zwrap/example_test.go
+++ b/zwrap/example_test.go
@@ -22,6 +22,7 @@ package zwrap_test
 
 import (
 	"strconv"
+	"time"
 
 	"github.com/uber-common/zap"
 	"github.com/uber-common/zap/zwrap"
@@ -49,8 +50,8 @@ func Example_standardize() {
 }
 
 func Example_sample() {
-	// Log the first message, and every 100th message thereafter.
-	sampledLogger := zwrap.Sample(zap.NewJSON(), 1, 100)
+	// Every second, log the first message and every hundredth message thereafter.
+	sampledLogger := zwrap.Sample(zap.NewJSON(), time.Second, 1, 100)
 	// Stub the current time in tests.
 	sampledLogger.StubTime()
 

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -91,14 +91,11 @@ func (s *sampler) Fatal(msg string, fields ...zap.Field) {
 	}
 }
 
-/* TODO: Depends on #35.
 func (s *sampler) DFatal(msg string, fields ...zap.Field) {
 	if s.check(zap.Error) {
 		s.Logger.DFatal(msg, fields...)
 	}
-
 }
-*/
 
 func (s *sampler) check(lvl zap.Level) bool {
 	// If this log level isn't enabled, don't count this statement.

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -35,16 +35,16 @@ type counters struct {
 
 func (c *counters) Inc(key string) uint64 {
 	c.RLock()
-	if _, ok := c.counts[key]; !ok {
-		c.RUnlock()
-		zero := uint64(0)
-		c.Lock()
-		c.counts[key] = &zero
-		c.Unlock()
-		c.RLock()
-	}
-	count := c.counts[key]
+	count, ok := c.counts[key]
 	c.RUnlock()
+
+	if !ok {
+		one := uint64(1)
+		c.Lock()
+		c.counts[key] = &one
+		c.Unlock()
+		return 1
+	}
 	return atomic.AddUint64(count, 1)
 }
 

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zwrap
+
+import (
+	"sync/atomic"
+
+	"github.com/uber-common/zap"
+)
+
+// Sample returns a sampling logger that logs the first N statements and every
+// Mth statement thereafter. Sampling loggers are safe for concurrent use.
+//
+// The children of sampling loggers (i.e., the results of calls to the With method)
+// inherit their parent's sampling logic but maintain independent counters.
+func Sample(zl zap.Logger, first int, thereafter int) zap.Logger {
+	return &sampler{
+		Logger:     zl,
+		first:      uint64(first),
+		thereafter: uint64(thereafter),
+	}
+}
+
+type sampler struct {
+	zap.Logger
+
+	count      uint64
+	first      uint64
+	thereafter uint64
+}
+
+func (s *sampler) With(fields ...zap.Field) zap.Logger {
+	return &sampler{
+		Logger:     s.Logger.With(fields...),
+		first:      s.first,
+		thereafter: s.thereafter,
+	}
+}
+
+func (s *sampler) Debug(msg string, fields ...zap.Field) {
+	if s.check(zap.Debug) {
+		s.Logger.Debug(msg, fields...)
+	}
+}
+
+func (s *sampler) Info(msg string, fields ...zap.Field) {
+	if s.check(zap.Info) {
+		s.Logger.Info(msg, fields...)
+	}
+}
+
+func (s *sampler) Warn(msg string, fields ...zap.Field) {
+	if s.check(zap.Warn) {
+		s.Logger.Warn(msg, fields...)
+	}
+}
+
+func (s *sampler) Error(msg string, fields ...zap.Field) {
+	if s.check(zap.Error) {
+		s.Logger.Error(msg, fields...)
+	}
+}
+
+func (s *sampler) Panic(msg string, fields ...zap.Field) {
+	if s.check(zap.Panic) {
+		s.Logger.Panic(msg, fields...)
+	}
+}
+
+func (s *sampler) Fatal(msg string, fields ...zap.Field) {
+	if s.check(zap.Fatal) {
+		s.Logger.Fatal(msg, fields...)
+	}
+}
+
+/* TODO: Depends on #35.
+func (s *sampler) DFatal(msg string, fields ...zap.Field) {
+	if s.check(zap.Error) {
+		s.Logger.DFatal(msg, fields...)
+	}
+
+}
+*/
+
+func (s *sampler) check(lvl zap.Level) bool {
+	// If this log level isn't enabled, don't count this statement.
+	if !s.Enabled(lvl) {
+		return false
+	}
+	n := atomic.AddUint64(&s.count, 1)
+	if n <= s.first {
+		return true
+	}
+	return (n-s.first)%s.thereafter == 0
+}

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -21,22 +21,26 @@
 package zwrap
 
 import (
+	"runtime"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/uber-common/zap"
 )
 
+var _callersPool = sync.Pool{
+	New: func() interface{} { return [1]uintptr{} },
+}
+
 // Sample returns a sampling logger. Each tick, the sampler records the first N
-// messages and every Mth message thereafter. Sampling loggers are safe for
-// concurrent use.
-//
-// The children of sampling loggers (i.e., the results of calls to the With method)
-// inherit their parent's sampling logic but maintain independent counters.
+// messages from each call site and every Mth message thereafter. Sampling
+// loggers are safe for concurrent use.
 func Sample(zl zap.Logger, tick time.Duration, first, thereafter int) zap.Logger {
 	return &sampler{
 		Logger:     zl,
 		tick:       tick,
+		counts:     make(map[uintptr]*uint64),
 		first:      uint64(first),
 		thereafter: uint64(thereafter),
 	}
@@ -44,9 +48,10 @@ func Sample(zl zap.Logger, tick time.Duration, first, thereafter int) zap.Logger
 
 type sampler struct {
 	zap.Logger
+	sync.RWMutex
 
 	tick       time.Duration
-	count      uint64
+	counts     map[uintptr]*uint64
 	first      uint64
 	thereafter uint64
 }
@@ -55,6 +60,7 @@ func (s *sampler) With(fields ...zap.Field) zap.Logger {
 	return &sampler{
 		Logger:     s.Logger.With(fields...),
 		tick:       s.tick,
+		counts:     make(map[uintptr]*uint64),
 		first:      s.first,
 		thereafter: s.thereafter,
 	}
@@ -107,17 +113,39 @@ func (s *sampler) check(lvl zap.Level) bool {
 	if !s.Enabled(lvl) {
 		return false
 	}
-	n := atomic.AddUint64(&s.count, 1)
+
+	// Allocate this on the stack, since it doesn't escape.
+	callers := [1]uintptr{}
+	// Note that the skip argument for runtime.Callers is subtly different from
+	// the skip argument for runtime.Caller.
+	runtime.Callers(3, callers[:])
+	caller := callers[0]
+
+	s.RLock()
+	if _, ok := s.counts[caller]; !ok {
+		s.RUnlock()
+		zero := uint64(0)
+		s.Lock()
+		s.counts[caller] = &zero
+		s.Unlock()
+		s.RLock()
+	}
+	count := s.counts[caller]
+	s.RUnlock()
+	n := atomic.AddUint64(count, 1)
 	if n <= s.first {
 		return true
 	}
 	if n == s.first+1 {
 		// We've started sampling, reset the counter in a tick.
-		time.AfterFunc(s.tick, func() { s.Reset() })
+		time.AfterFunc(s.tick, func() { s.Reset(caller) })
 	}
 	return (n-s.first)%s.thereafter == 0
 }
 
-func (s *sampler) Reset() {
-	atomic.StoreUint64(&s.count, 0)
+func (s *sampler) Reset(caller uintptr) {
+	s.Lock()
+	count := s.counts[caller]
+	s.Unlock()
+	atomic.StoreUint64(count, 0)
 }

--- a/zwrap/sample_test.go
+++ b/zwrap/sample_test.go
@@ -33,8 +33,7 @@ import (
 )
 
 func fakeSampler(tick time.Duration, first, thereafter int, development bool) (zap.Logger, *spy.Sink) {
-	sink := &spy.Sink{}
-	base := spy.New(sink)
+	base, sink := spy.New()
 	base.SetLevel(zap.All)
 	base.SetDevelopment(development)
 	sampler := Sample(base, tick, first, thereafter)

--- a/zwrap/sample_test.go
+++ b/zwrap/sample_test.go
@@ -82,7 +82,6 @@ func TestSampler(t *testing.T) {
 			level:   zap.Fatal,
 			logFunc: func(sampler zap.Logger, msg string) { sampler.Fatal(msg) },
 		},
-		/* TODO: Depends on PR #35.
 		{
 			level:   zap.Error,
 			logFunc: func(sampler zap.Logger, msg string) { sampler.DFatal(msg) },
@@ -92,7 +91,6 @@ func TestSampler(t *testing.T) {
 			logFunc:     func(sampler zap.Logger, msg string) { sampler.DFatal(msg) },
 			development: true,
 		},
-		*/
 	}
 
 	for _, tt := range tests {

--- a/zwrap/sample_test.go
+++ b/zwrap/sample_test.go
@@ -151,7 +151,7 @@ func TestSamplerTicks(t *testing.T) {
 	// tick, the third statement should be logged.
 	for i := 1; i < 4; i++ {
 		if i == 3 {
-			time.Sleep(2 * time.Millisecond)
+			time.Sleep(5 * time.Millisecond)
 		}
 		WithIter(sampler, i).Info("sample")
 	}

--- a/zwrap/sample_test.go
+++ b/zwrap/sample_test.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zwrap
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/uber-common/zap"
+	"github.com/uber-common/zap/spy"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func fakeSampler(first, thereafter int, development bool) (zap.Logger, *spy.Sink) {
+	sink := &spy.Sink{}
+	base := spy.New(sink)
+	base.SetLevel(zap.All)
+	base.SetDevelopment(development)
+	sampler := Sample(base, first, thereafter)
+	return sampler, sink
+}
+
+func buildExpectation(level zap.Level, messages ...string) []spy.Log {
+	var expected []spy.Log
+	for _, m := range messages {
+		expected = append(expected, spy.Log{
+			Level:  level,
+			Msg:    m,
+			Fields: make([]zap.Field, 0),
+		})
+	}
+	return expected
+}
+
+func TestSampler(t *testing.T) {
+	tests := []struct {
+		level       zap.Level
+		logFunc     func(zap.Logger, string)
+		development bool
+	}{
+		{
+			level:   zap.Debug,
+			logFunc: func(sampler zap.Logger, msg string) { sampler.Debug(msg) },
+		},
+		{
+			level:   zap.Info,
+			logFunc: func(sampler zap.Logger, msg string) { sampler.Info(msg) },
+		},
+		{
+			level:   zap.Warn,
+			logFunc: func(sampler zap.Logger, msg string) { sampler.Warn(msg) },
+		},
+		{
+			level:   zap.Error,
+			logFunc: func(sampler zap.Logger, msg string) { sampler.Error(msg) },
+		},
+		{
+			level:   zap.Panic,
+			logFunc: func(sampler zap.Logger, msg string) { sampler.Panic(msg) },
+		},
+		{
+			level:   zap.Fatal,
+			logFunc: func(sampler zap.Logger, msg string) { sampler.Fatal(msg) },
+		},
+		/* TODO: Depends on PR #35.
+		{
+			level:   zap.Error,
+			logFunc: func(sampler zap.Logger, msg string) { sampler.DFatal(msg) },
+		},
+		{
+			level:       zap.Fatal,
+			logFunc:     func(sampler zap.Logger, msg string) { sampler.DFatal(msg) },
+			development: true,
+		},
+		*/
+	}
+
+	for _, tt := range tests {
+		sampler, sink := fakeSampler(2, 3, tt.development)
+		for i := 1; i < 10; i++ {
+			tt.logFunc(sampler, strconv.Itoa(i))
+		}
+		expected := buildExpectation(tt.level, "1", "2", "5", "8")
+		assert.Equal(t, expected, sink.Logs(), "Unexpected output from sampled logger.")
+	}
+}
+
+func TestSampledDisabledLevels(t *testing.T) {
+	sampler, sink := fakeSampler(1, 100, false)
+	sampler.SetLevel(zap.Info)
+
+	// Shouldn't be counted, because debug logging isn't enabled.
+	sampler.Debug("1")
+	sampler.Info("2")
+	expected := buildExpectation(zap.Info, "2")
+	assert.Equal(t, expected, sink.Logs(), "Expected to disregard disabled log levels.")
+}
+
+func TestSamplerWith(t *testing.T) {
+	// Check that child loggers are sampled and independent.
+	sampler, sink := fakeSampler(1, 100, false)
+
+	expected := []spy.Log{
+		{
+			Level:  zap.Info,
+			Msg:    "1",
+			Fields: []zap.Field{zap.String("child", "first")},
+		},
+		{
+			Level:  zap.Info,
+			Msg:    "20",
+			Fields: []zap.Field{zap.String("child", "second")},
+		},
+	}
+
+	first := sampler.With(zap.String("child", "first"))
+	for i := 1; i < 100; i++ {
+		first.Info(strconv.Itoa(i))
+	}
+	second := sampler.With(zap.String("child", "second"))
+	// Even though the first child already logged 20 messages, we should see the
+	// first message from this child.
+	for i := 20; i < 40; i++ {
+		second.Info(strconv.Itoa(i))
+	}
+
+	assert.Equal(t, expected, sink.Logs(), "Expected child loggers to maintain separate counters.")
+}
+
+func TestSamplerRaces(t *testing.T) {
+	sampler, _ := fakeSampler(1, 1000, false)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			<-start
+			for j := 0; j < 100; j++ {
+				sampler.Info("Testing for races.")
+			}
+			wg.Done()
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+}


### PR DESCRIPTION
Add a sampling wrapper that logs the first N messages and every Mth
message thereafter. Results of the included sampler benchmark:

```
BenchmarkSampledZap-4   50000000    33.9 ns/op  0 B/op  0 allocs/op
```

Fixes #19, which @nomis52 wanted.