### PR TITLE
Renaming in preparation for an arbitrary-object field

### DIFF
--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -63,7 +63,7 @@ func BenchmarkZapAddingFields(b *testing.B) {
 				zap.Time("time", time.Unix(0, 0)),
 				zap.Err(errExample),
 				zap.Duration("duration", time.Second),
-				zap.Object("user-defined type", _jane),
+				zap.Marshaler("user-defined type", _jane),
 				zap.String("another string", "done!"),
 			)
 		}
@@ -80,7 +80,7 @@ func BenchmarkZapWithAccumulatedContext(b *testing.B) {
 		zap.Time("time", time.Unix(0, 0)),
 		zap.Err(errExample),
 		zap.Duration("duration", time.Second),
-		zap.Object("user-defined type", _jane),
+		zap.Marshaler("user-defined type", _jane),
 		zap.String("another string", "done!"),
 	))
 	b.ResetTimer()

--- a/field.go
+++ b/field.go
@@ -46,7 +46,7 @@ type Field struct {
 	fieldType fieldType
 	ival      int64
 	str       string
-	obj       Marshaler
+	marshaler LogMarshaler
 }
 
 // Bool constructs a Field with the given key and value.
@@ -116,17 +116,17 @@ func Duration(key string, val time.Duration) Field {
 	return Int64(key, int64(val))
 }
 
-// Object constructs a field with the given key and zap.Marshaler. It provides a
-// flexible, but still type-safe and efficient, way to add user-defined types to
-// the logging context.
-func Object(key string, val Marshaler) Field {
-	return Field{key: key, fieldType: marshalerType, obj: val}
+// Marshaler constructs a field with the given key and zap.LogMarshaler. It
+// provides a flexible, but still type-safe and efficient, way to add
+// user-defined types to the logging context.
+func Marshaler(key string, val LogMarshaler) Field {
+	return Field{key: key, fieldType: marshalerType, marshaler: val}
 }
 
 // Nest takes a key and a variadic number of Fields and creates a nested
 // namespace.
 func Nest(key string, fields ...Field) Field {
-	return Field{key: key, fieldType: marshalerType, obj: multiFields(fields)}
+	return Field{key: key, fieldType: marshalerType, marshaler: multiFields(fields)}
 }
 
 func (f Field) addTo(kv KeyValue) error {
@@ -142,7 +142,7 @@ func (f Field) addTo(kv KeyValue) error {
 	case stringType:
 		kv.AddString(f.key, f.str)
 	case marshalerType:
-		return kv.AddObject(f.key, f.obj)
+		return kv.AddMarshaler(f.key, f.marshaler)
 	default:
 		panic(fmt.Sprintf("unknown field type found: %v", f))
 	}

--- a/field_test.go
+++ b/field_test.go
@@ -118,12 +118,12 @@ func TestDurationField(t *testing.T) {
 	assertCanBeReused(t, Duration("foo", time.Nanosecond))
 }
 
-func TestObjectField(t *testing.T) {
+func TestMarshalerField(t *testing.T) {
 	// Marshaling the user failed, so we expect an empty object.
-	assertFieldJSON(t, `"foo":{}`, Object("foo", fakeUser{"fail"}))
+	assertFieldJSON(t, `"foo":{}`, Marshaler("foo", fakeUser{"fail"}))
 
-	assertFieldJSON(t, `"foo":{"name":"phil"}`, Object("foo", fakeUser{"phil"}))
-	assertCanBeReused(t, Object("foo", fakeUser{"phil"}))
+	assertFieldJSON(t, `"foo":{"name":"phil"}`, Marshaler("foo", fakeUser{"phil"}))
+	assertCanBeReused(t, Marshaler("foo", fakeUser{"phil"}))
 }
 
 func TestNestField(t *testing.T) {
@@ -132,7 +132,7 @@ func TestNestField(t *testing.T) {
 	)
 	// Marshaling the user failed, so we expect an empty object.
 	assertFieldJSON(t, `"foo":{"user":{}}`,
-		Nest("foo", Object("user", fakeUser{"fail"})),
+		Nest("foo", Marshaler("user", fakeUser{"fail"})),
 	)
 
 	nest := Nest("foo", String("name", "phil"), Int("age", 42))

--- a/json_encoder.go
+++ b/json_encoder.go
@@ -125,8 +125,8 @@ func (enc *jsonEncoder) Nest(key string, f func(KeyValue) error) error {
 	return err
 }
 
-// AddObject adds a Marshaler to the encoder's fields.
-func (enc *jsonEncoder) AddObject(key string, obj Marshaler) error {
+// AddMarshaler adds a LogMarshaler to the encoder's fields.
+func (enc *jsonEncoder) AddMarshaler(key string, obj LogMarshaler) error {
 	return enc.Nest(key, func(kv KeyValue) error {
 		return obj.MarshalLog(kv)
 	})

--- a/json_encoder_test.go
+++ b/json_encoder_test.go
@@ -156,10 +156,10 @@ func (l loggable) MarshalLog(kv KeyValue) error {
 	return nil
 }
 
-func TestJSONAddObject(t *testing.T) {
+func TestJSONAddMarshaler(t *testing.T) {
 	withJSONEncoder(func(enc *jsonEncoder) {
-		err := enc.AddObject("nested", loggable{})
-		require.NoError(t, err, "Unexpected error using AddObject.")
+		err := enc.AddMarshaler("nested", loggable{})
+		require.NoError(t, err, "Unexpected error using AddMarshaler.")
 		assertJSON(t, `"foo":"bar","nested":{"loggable":"yes"}`, enc)
 	})
 }

--- a/keyvalue.go
+++ b/keyvalue.go
@@ -30,7 +30,7 @@ type KeyValue interface {
 	AddFloat64(string, float64)
 	AddInt(string, int)
 	AddInt64(string, int64)
-	AddObject(string, Marshaler) error
+	AddMarshaler(string, LogMarshaler) error
 	AddString(string, string)
 	Nest(string, func(KeyValue) error) error
 }

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -125,7 +125,7 @@ func BenchmarkStackField(b *testing.B) {
 	})
 }
 
-func BenchmarkObjectField(b *testing.B) {
+func BenchmarkMarshalerField(b *testing.B) {
 	// Expect an extra allocation here, since casting the user struct to the
 	// zap.Marshaler interface costs an alloc.
 	u := user{
@@ -134,7 +134,7 @@ func BenchmarkObjectField(b *testing.B) {
 		createdAt: time.Unix(0, 0),
 	}
 	withBenchedLogger(b, func(log zap.Logger) {
-		log.Info("Arbitrary zap.Marshaler.", zap.Object("user", u))
+		log.Info("Arbitrary zap.LogMarshaler.", zap.Marshaler("user", u))
 	})
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -194,7 +194,7 @@ func TestJSONLoggerInternalErrorHandling(t *testing.T) {
 	buf := newTestBuffer()
 	errBuf := newTestBuffer()
 
-	jl := NewJSON(All, Output(buf), ErrorOutput(errBuf), Fields(Object("user", fakeUser{"fail"})))
+	jl := NewJSON(All, Output(buf), ErrorOutput(errBuf), Fields(Marshaler("user", fakeUser{"fail"})))
 	jl.StubTime()
 	output := func() []string { return strings.Split(buf.String(), "\n") }
 

--- a/marshaler.go
+++ b/marshaler.go
@@ -20,9 +20,9 @@
 
 package zap
 
-// Marshaler allows user-defined types to efficiently add themselves to the
+// LogMarshaler allows user-defined types to efficiently add themselves to the
 // logging context, and to selectively omit information which shouldn't be
 // included in logs (e.g., passwords).
-type Marshaler interface {
+type LogMarshaler interface {
 	MarshalLog(KeyValue) error
 }

--- a/marshaler_example_test.go
+++ b/marshaler_example_test.go
@@ -49,7 +49,7 @@ type User struct {
 func (u User) MarshalLog(kv zap.KeyValue) error {
 	kv.AddString("name", u.Name)
 	kv.AddInt("age", u.Age)
-	return kv.AddObject("auth", u.Auth)
+	return kv.AddMarshaler("auth", u.Auth)
 }
 
 func ExampleMarshaler() {
@@ -65,7 +65,7 @@ func ExampleMarshaler() {
 	logger := zap.NewJSON()
 	// Stub time in tests.
 	logger.StubTime()
-	logger.Info("Successful login.", zap.Object("user", jane))
+	logger.Info("Successful login.", zap.Marshaler("user", jane))
 
 	// Output:
 	// {"msg":"Successful login.","level":"info","ts":0,"fields":{"user":{"name":"Jane Doe","age":42,"auth":{"expires_at":100,"token":"---"}}}}

--- a/zbark/bark.go
+++ b/zbark/bark.go
@@ -152,8 +152,8 @@ func (l *logger) addZapFields(fs bark.Fields) unsafeJSONLogger {
 		case time.Duration:
 			zfs = append(zfs, zap.Duration(key, v))
 		// zap.Marshaler takes precedence over other interfaces.
-		case zap.Marshaler:
-			zfs = append(zfs, zap.Object(key, v))
+		case zap.LogMarshaler:
+			zfs = append(zfs, zap.Marshaler(key, v))
 		case error:
 			// zap.Err ignores the user-supplied key.
 			zfs = append(zfs, zap.String(key, v.Error()))


### PR DESCRIPTION
In preparation for a real arbitrary-object field, rename `Object` -> `Marshaler` and `Marshaler` -> `LogMarshaler`.