### PR TITLE
Add zap.Object to log arbitrary objects

### DIFF
--- a/field.go
+++ b/field.go
@@ -47,7 +47,6 @@ type Field struct {
 	fieldType fieldType
 	ival      int64
 	str       string
-	marshaler LogMarshaler
 	obj       interface{}
 }
 
@@ -122,7 +121,7 @@ func Duration(key string, val time.Duration) Field {
 // provides a flexible, but still type-safe and efficient, way to add
 // user-defined types to the logging context.
 func Marshaler(key string, val LogMarshaler) Field {
-	return Field{key: key, fieldType: marshalerType, marshaler: val}
+	return Field{key: key, fieldType: marshalerType, obj: val}
 }
 
 // Object constructs a field with the given key and an arbitrary object. It uses
@@ -138,7 +137,7 @@ func Object(key string, val interface{}) Field {
 // Nest takes a key and a variadic number of Fields and creates a nested
 // namespace.
 func Nest(key string, fields ...Field) Field {
-	return Field{key: key, fieldType: marshalerType, marshaler: multiFields(fields)}
+	return Field{key: key, fieldType: marshalerType, obj: multiFields(fields)}
 }
 
 func (f Field) addTo(kv KeyValue) error {
@@ -154,7 +153,7 @@ func (f Field) addTo(kv KeyValue) error {
 	case stringType:
 		kv.AddString(f.key, f.str)
 	case marshalerType:
-		return kv.AddMarshaler(f.key, f.marshaler)
+		return kv.AddMarshaler(f.key, f.obj.(LogMarshaler))
 	case objectType:
 		kv.AddObject(f.key, f.obj)
 	default:

--- a/field_test.go
+++ b/field_test.go
@@ -126,6 +126,11 @@ func TestMarshalerField(t *testing.T) {
 	assertCanBeReused(t, Marshaler("foo", fakeUser{"phil"}))
 }
 
+func TestObjectField(t *testing.T) {
+	assertFieldJSON(t, `"foo":[5,6]`, Object("foo", []int{5, 6}))
+	assertCanBeReused(t, Object("foo", []int{5, 6}))
+}
+
 func TestNestField(t *testing.T) {
 	assertFieldJSON(t, `"foo":{"name":"phil","age":42}`,
 		Nest("foo", String("name", "phil"), Int("age", 42)),

--- a/json_encoder_test.go
+++ b/json_encoder_test.go
@@ -104,14 +104,6 @@ func TestJSONAddFloat64(t *testing.T) {
 	})
 }
 
-func TestJSONUnsafeAddBytes(t *testing.T) {
-	withJSONEncoder(func(enc *jsonEncoder) {
-		// Keys should be escaped.
-		enc.UnsafeAddBytes(`baz\`, []byte(`{"inner":42}`))
-		assertJSON(t, `"foo":"bar","baz\\":{"inner":42}`, enc)
-	})
-}
-
 func TestJSONWriteMessage(t *testing.T) {
 	withJSONEncoder(func(enc *jsonEncoder) {
 		sink := bytes.NewBuffer(nil)
@@ -161,6 +153,18 @@ func TestJSONAddMarshaler(t *testing.T) {
 		err := enc.AddMarshaler("nested", loggable{})
 		require.NoError(t, err, "Unexpected error using AddMarshaler.")
 		assertJSON(t, `"foo":"bar","nested":{"loggable":"yes"}`, enc)
+	})
+}
+
+func TestJSONAddObject(t *testing.T) {
+	withJSONEncoder(func(enc *jsonEncoder) {
+		enc.AddObject("nested", map[string]string{"loggable": "yes"})
+		assertJSON(t, `"foo":"bar","nested":{"loggable":"yes"}`, enc)
+	})
+
+	withJSONEncoder(func(enc *jsonEncoder) {
+		enc.AddObject("nested", map[int]string{42: "yes"})
+		assertJSON(t, `"foo":"bar","nested":"json: unsupported type: map[int]string"`, enc)
 	})
 }
 

--- a/keyvalue.go
+++ b/keyvalue.go
@@ -31,6 +31,9 @@ type KeyValue interface {
 	AddInt(string, int)
 	AddInt64(string, int64)
 	AddMarshaler(string, LogMarshaler) error
+	// AddObject uses reflection to serialize arbitrary objects, so it's slow and
+	// allocation-heavy. Consider implementing the LogMarshaler interface instead.
+	AddObject(string, interface{})
 	AddString(string, string)
 	Nest(string, func(KeyValue) error) error
 }

--- a/logger.go
+++ b/logger.go
@@ -122,16 +122,6 @@ func (jl *jsonLogger) With(fields ...Field) Logger {
 	return clone
 }
 
-// WithUnsafeJSON adds a key and a slice of arbitrary bytes to the logging
-// context. It's highly unsafe, and intended only for use by the zbark wrappers.
-//
-// For details, see jsonEncoder.UnsafeAddBytes.
-func (jl *jsonLogger) WithUnsafeJSON(key string, val []byte) Logger {
-	clone := jl.With().(*jsonLogger)
-	clone.enc.(*jsonEncoder).UnsafeAddBytes(key, val)
-	return clone
-}
-
 func (jl *jsonLogger) StubTime() {
 	jl.alwaysEpoch = true
 }

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -29,22 +29,22 @@ import (
 )
 
 type user struct {
-	name      string
-	email     string
-	createdAt time.Time
+	Name      string
+	Email     string
+	CreatedAt time.Time
 }
 
 func (u user) MarshalLog(kv zap.KeyValue) error {
-	kv.AddString("name", u.name)
-	kv.AddString("email", u.email)
-	kv.AddInt64("created_at", u.createdAt.UnixNano())
+	kv.AddString("name", u.Name)
+	kv.AddString("email", u.Email)
+	kv.AddInt64("created_at", u.CreatedAt.UnixNano())
 	return nil
 }
 
 var _jane = user{
-	name:      "Jane Doe",
-	email:     "jane@test.com",
-	createdAt: time.Date(1980, 1, 1, 12, 0, 0, 0, time.UTC),
+	Name:      "Jane Doe",
+	Email:     "jane@test.com",
+	CreatedAt: time.Date(1980, 1, 1, 12, 0, 0, 0, time.UTC),
 }
 
 func withBenchedLogger(b *testing.B, f func(zap.Logger)) {
@@ -128,13 +128,14 @@ func BenchmarkStackField(b *testing.B) {
 func BenchmarkMarshalerField(b *testing.B) {
 	// Expect an extra allocation here, since casting the user struct to the
 	// zap.Marshaler interface costs an alloc.
-	u := user{
-		name:      "Jane Example",
-		email:     "jane@example.com",
-		createdAt: time.Unix(0, 0),
-	}
 	withBenchedLogger(b, func(log zap.Logger) {
-		log.Info("Arbitrary zap.LogMarshaler.", zap.Marshaler("user", u))
+		log.Info("Arbitrary zap.LogMarshaler.", zap.Marshaler("user", _jane))
+	})
+}
+
+func BenchmarkObjectField(b *testing.B) {
+	withBenchedLogger(b, func(log zap.Logger) {
+		log.Info("Reflection-based serialization.", zap.Object("user", _jane))
 	})
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -131,13 +131,6 @@ func TestJSONLoggerWith(t *testing.T) {
 	})
 }
 
-func TestJSONLoggerWithUnsafeJSON(t *testing.T) {
-	withJSONLogger(t, nil, func(jl *jsonLogger, output func() []string) {
-		jl.WithUnsafeJSON(`foo\`, []byte(`{"inner":42}`)).Debug("")
-		assertFields(t, jl, output, `{"foo\\":{"inner":42}}`)
-	})
-}
-
 func TestJSONLoggerDebug(t *testing.T) {
 	withJSONLogger(t, nil, func(jl *jsonLogger, output func() []string) {
 		jl.Debug("foo")


### PR DESCRIPTION
Introduce zap.Object, which uses encoding-appropriate reflection to log
truly arbitrary objects. This introduces an API that's not fast by
default, but it makes the zbark wrapper much cleaner.