### PR TITLE
Stop escaping '/' which JSON does not require

### DIFF
--- a/json_encoder.go
+++ b/json_encoder.go
@@ -200,12 +200,12 @@ func (enc *jsonEncoder) safeAddString(s string) {
 	for i := 0; i < len(s); {
 		if b := s[i]; b < utf8.RuneSelf {
 			i++
-			if 0x20 <= b && b != '\\' && b != '/' && b != '"' {
+			if 0x20 <= b && b != '\\' && b != '"' {
 				enc.bytes = append(enc.bytes, b)
 				continue
 			}
 			switch b {
-			case '\\', '/', '"':
+			case '\\', '"':
 				enc.bytes = append(enc.bytes, '\\', b)
 			case '\n':
 				enc.bytes = append(enc.bytes, '\\', 'n')

--- a/json_encoder_test.go
+++ b/json_encoder_test.go
@@ -205,7 +205,6 @@ func TestJSONJSONEscaping(t *testing.T) {
 		// Special-cased characters.
 		`"`: `\"`,
 		`\`: `\\`,
-		`/`: `\/`,
 		// Special-cased characters within everyday ASCII.
 		`foo"foo`: `foo\"foo`,
 		"foo\n":   `foo\n`,


### PR DESCRIPTION
Escaping '/' makes URLs longer and harder to read, and isn't required by
the JSON spec.