### PR TITLE
Add a Log method to Logger interface

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -50,6 +50,7 @@ type Logger interface {
 
 	// Log a message at the given level. Messages include any context that's
 	// accumulated on the logger, as well as any fields added at the log site.
+	Log(Level, string, ...Field)
 	Debug(string, ...Field)
 	Info(string, ...Field)
 	Warn(string, ...Field)
@@ -127,6 +128,17 @@ func (jl *jsonLogger) With(fields ...Field) Logger {
 
 func (jl *jsonLogger) StubTime() {
 	jl.alwaysEpoch = true
+}
+
+func (jl *jsonLogger) Log(lvl Level, msg string, fields ...Field) {
+	switch lvl {
+	case Panic:
+		jl.Panic(msg, fields...)
+	case Fatal:
+		jl.Fatal(msg, fields...)
+	default:
+		jl.log(lvl, msg, fields)
+	}
 }
 
 func (jl *jsonLogger) Debug(msg string, fields ...Field) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -131,6 +131,17 @@ func TestJSONLoggerWith(t *testing.T) {
 	})
 }
 
+func TestJSONLoggerLog(t *testing.T) {
+	withJSONLogger(t, nil, func(jl *jsonLogger, output func() []string) {
+		jl.Log(Debug, "foo")
+		assertMessage(t, "debug", "foo", output()[0])
+	})
+	withJSONLogger(t, nil, func(jl *jsonLogger, output func() []string) {
+		assert.Panics(t, func() { jl.Log(Panic, "foo") }, "Expected logging at Panic level to panic.")
+		assertMessage(t, "panic", "foo", output()[0])
+	})
+}
+
 func TestJSONLoggerDebug(t *testing.T) {
 	withJSONLogger(t, nil, func(jl *jsonLogger, output func() []string) {
 		jl.Debug("foo")

--- a/spy/logger.go
+++ b/spy/logger.go
@@ -124,6 +124,11 @@ func (l *Logger) With(fields ...zap.Field) zap.Logger {
 	}
 }
 
+// Log writes a message at the specified level.
+func (l *Logger) Log(lvl zap.Level, msg string, fields ...zap.Field) {
+	l.sink.WriteLog(lvl, msg, l.allFields(fields))
+}
+
 // Debug logs at the Debug level.
 func (l *Logger) Debug(msg string, fields ...zap.Field) {
 	l.sink.WriteLog(zap.Debug, msg, l.allFields(fields))

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -97,6 +97,12 @@ func (s *sampler) With(fields ...zap.Field) zap.Logger {
 	}
 }
 
+func (s *sampler) Log(lvl zap.Level, msg string, fields ...zap.Field) {
+	if s.check(lvl, msg) {
+		s.Logger.Log(lvl, msg, fields...)
+	}
+}
+
 func (s *sampler) Debug(msg string, fields ...zap.Field) {
 	if s.check(zap.Debug, msg) {
 		s.Logger.Debug(msg, fields...)

--- a/zwrap/sample_test.go
+++ b/zwrap/sample_test.go
@@ -94,6 +94,10 @@ func TestSampler(t *testing.T) {
 			logFunc:     func(sampler zap.Logger, n int) { WithIter(sampler, n).DFatal("sample") },
 			development: true,
 		},
+		{
+			level:   zap.Error,
+			logFunc: func(sampler zap.Logger, n int) { WithIter(sampler, n).Log(zap.Error, "sample") },
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Add a method to all the loggers that allows users to pass the level as a parameter (instead of calling a named method). This is a precursor to introducing a faster (though less convenient) sampling API.